### PR TITLE
18 flaskapp + agregar cabecera cors a las respuestas de los endpoints

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,5 +1,6 @@
 # Packages
 from flask import Flask
+from flask_cors import CORS
 import os
 
 # Local files
@@ -25,6 +26,10 @@ def create_firebase_admin():
 
 def create_app():
     flask_app = Flask(__name__, instance_relative_config=True)
+
+    # This allows access from any origin. To restrict to certain domain replace "*" with url
+    CORS(flask_app)
+    flask_app.config['CORS_HEADERS'] = 'Content-Type'
 
     # Get environment, if not defined 'development' will be default
     environment = os.getenv('FLASK_ENV', 'development')

--- a/app/route/health.py
+++ b/app/route/health.py
@@ -13,7 +13,7 @@ def hello():
 
 @health_bp.route('/get-environment')
 def get_environment():
-    return jsonify({'Environment': current_app.config['ENVIRONMENT']}), 200
+    return jsonify({'message': current_app.config['ENVIRONMENT']}), 200
 
 
 @health_bp.route('/get-version')
@@ -21,6 +21,6 @@ def get_version():
     try:
         with open('version_info.txt', 'r') as file:
             version_info = file.read()
-        return jsonify({'Application Version': version_info})
+        return jsonify({'message': version_info})
     except json.JSONDecodeError as e:
         return jsonify({'error': f'Could not read version information from file: {str(e)}'})

--- a/prepare_version.py
+++ b/prepare_version.py
@@ -1,4 +1,3 @@
-import os
 import subprocess
 
 
@@ -12,7 +11,7 @@ is_dirty = '1' if git_diff else '0'
 commit_hash = run_command("git rev-parse HEAD")[:6]
 
 version_info = f"""
-'1.0.{git_version}.{is_dirty}' - {commit_hash};
+1.0.{git_version}.{is_dirty} - {commit_hash}
 """
 
 file_path = "version_info.txt"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pyrebase4
 gunicorn
 firebase-admin
 setuptools
+flask-cors


### PR DESCRIPTION
Se implementó la cabecera CORS en la respuesta de los endpoints. 

Se agregó "flask_cors" a los paquetes de requirements.txt. 

Se corrigió un label en "prepare_version"

Se hizo un refactor de las respuestas de los endpoints del controller "Health"